### PR TITLE
Replace com.ibm.icu dependency with org.eclipse.ant.core in expressio…

### DIFF
--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/ant/core/AntRunner.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/ant/core/AntRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,19 +11,25 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package com.ibm.icu.text;
+package org.eclipse.ant.core;
+
+import java.io.Serializable;
 
 /**
  * Used by the
  * {@link org.eclipse.core.internal.expressions.tests.ExpressionTestsPluginUnloading}
  * test.
  * <p>
- * <strong>Note:</strong> This class uses the 'com.ibm.icu.text' namespace for
- * test purposes only and does not copy or implement anything from ICU.
+ * <strong>Note:</strong> This class uses the 'org.eclipse.ant.core' namespace
+ * for test purposes only and does not copy or implement anything from the real
+ * AntRunner class.
  * </p>
  */
-public class DecimalFormat implements Runnable {
+public class AntRunner implements Runnable, Serializable {
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public void run() {
+		// Empty implementation for testing
 	}
 }

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
@@ -33,7 +33,7 @@ import org.eclipse.core.internal.expressions.Expressions;
 /**
  * Tests for cache used in {@link Expressions#isInstanceOf(Object, String)}.
  * <p>
- * <b>WARNING:</b> These tests start, stop, and re-start the <code>com.ibm.icu</code> bundle.
+ * <b>WARNING:</b> These tests start, stop, and re-start the <code>org.eclipse.ant.core</code> bundle.
  * Don't include these in another test suite!
  */
 @SuppressWarnings("restriction")
@@ -49,13 +49,13 @@ public class ExpressionTestsPluginUnloading {
 
 	@Test
 	public void test01PluginStopping() throws Exception {
-		Bundle bundle= getBundle("com.ibm.icu");
+		Bundle bundle= getBundle("org.eclipse.ant.core");
 		bundle.start();
 		int state = bundle.getState();
 		assertThat(state).withFailMessage("Unexpected bundle state: " + stateToString(state) + " for bundle " + bundle)
 				.isEqualTo(Bundle.ACTIVE);
 
-		doTestInstanceofICUDecimalFormat(bundle);
+		doTestInstanceofAntRunner(bundle);
 		assertThat(bundle.getState()).as("Instanceof with bundle-local class should load extra bundle")
 				.isEqualTo(state);
 
@@ -69,26 +69,26 @@ public class ExpressionTestsPluginUnloading {
 				.withFailMessage("Unexpected bundle state: " + stateToString(state) + " for bundle " + bundle)
 				.isEqualTo(Bundle.ACTIVE);
 
-		doTestInstanceofICUDecimalFormat(bundle);
+		doTestInstanceofAntRunner(bundle);
 	}
 
 	@Test
 	public void test02MultipleClassloaders() throws Exception {
 		Bundle expr= getBundle("org.eclipse.core.expressions.tests");
-		Bundle icu= getBundle("com.ibm.icu");
+		Bundle ant= getBundle("org.eclipse.ant.core");
 
-		Class<?> exprClass = expr.loadClass("com.ibm.icu.text.DecimalFormat");
-		Class<?> icuClass = icu.loadClass("com.ibm.icu.text.DecimalFormat");
-		assertThat(exprClass).isNotSameAs(icuClass);
+		Class<?> exprClass = expr.loadClass("org.eclipse.ant.core.AntRunner");
+		Class<?> antClass = ant.loadClass("org.eclipse.ant.core.AntRunner");
+		assertThat(exprClass).isNotSameAs(antClass);
 
 		Object exprObj = exprClass.getDeclaredConstructor().newInstance();
-		Object icuObj = icuClass.getDeclaredConstructor().newInstance();
+		Object antObj = antClass.getDeclaredConstructor().newInstance();
 
 		assertInstanceOf(exprObj, "java.lang.Runnable", "java.lang.String");
-		assertInstanceOf(exprObj, "java.lang.Object", "java.io.Serializable");
+		assertInstanceOf(exprObj, "java.io.Serializable", "org.eclipse.equinox.app.IApplication");
 
-		assertInstanceOf(icuObj, "java.io.Serializable", "java.lang.String");
-		assertInstanceOf(icuObj, "java.text.Format", "java.lang.Runnable");
+		assertInstanceOf(antObj, "org.eclipse.equinox.app.IApplication", "java.lang.String");
+		assertInstanceOf(antObj, "java.lang.Object", "java.lang.Runnable");
 	}
 
 	static String stateToString(int state) {
@@ -125,10 +125,10 @@ public class ExpressionTestsPluginUnloading {
 		}
 	}
 
-	private void doTestInstanceofICUDecimalFormat(Bundle bundle) throws Exception {
-		Class<?> clazz = bundle.loadClass("com.ibm.icu.text.DecimalFormat");
-		Object decimalFormat = clazz.getDeclaredConstructor().newInstance();
-		assertInstanceOf(decimalFormat, "com.ibm.icu.text.DecimalFormat", "java.text.NumberFormat");
+	private void doTestInstanceofAntRunner(Bundle bundle) throws Exception {
+		Class<?> clazz = bundle.loadClass("org.eclipse.ant.core.AntRunner");
+		Object antRunner = clazz.getDeclaredConstructor().newInstance();
+		assertInstanceOf(antRunner, "org.eclipse.ant.core.AntRunner", "java.lang.Runnable");
 	}
 
 	private static Bundle getBundle(String bundleName) {

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
@@ -40,6 +40,9 @@ import org.eclipse.core.internal.expressions.Expressions;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class ExpressionTestsPluginUnloading {
 
+	private static final String ANT_CORE_BUNDLE_ID = "org.eclipse.ant.core";
+	private static final String ANT_RUNNER_CLASS_NAME = "org.eclipse.ant.core.AntRunner";
+
 	private String name;
 
 	@BeforeEach
@@ -49,7 +52,7 @@ public class ExpressionTestsPluginUnloading {
 
 	@Test
 	public void test01PluginStopping() throws Exception {
-		Bundle bundle= getBundle("org.eclipse.ant.core");
+		Bundle bundle= getBundle(ANT_CORE_BUNDLE_ID);
 		bundle.start();
 		int state = bundle.getState();
 		assertThat(state).withFailMessage("Unexpected bundle state: " + stateToString(state) + " for bundle " + bundle)
@@ -75,10 +78,10 @@ public class ExpressionTestsPluginUnloading {
 	@Test
 	public void test02MultipleClassloaders() throws Exception {
 		Bundle expr= getBundle("org.eclipse.core.expressions.tests");
-		Bundle ant= getBundle("org.eclipse.ant.core");
+		Bundle ant= getBundle(ANT_CORE_BUNDLE_ID);
 
-		Class<?> exprClass = expr.loadClass("org.eclipse.ant.core.AntRunner");
-		Class<?> antClass = ant.loadClass("org.eclipse.ant.core.AntRunner");
+		Class<?> exprClass = expr.loadClass(ANT_RUNNER_CLASS_NAME);
+		Class<?> antClass = ant.loadClass(ANT_RUNNER_CLASS_NAME);
 		assertThat(exprClass).isNotSameAs(antClass);
 
 		Object exprObj = exprClass.getDeclaredConstructor().newInstance();
@@ -126,9 +129,9 @@ public class ExpressionTestsPluginUnloading {
 	}
 
 	private void doTestInstanceofAntRunner(Bundle bundle) throws Exception {
-		Class<?> clazz = bundle.loadClass("org.eclipse.ant.core.AntRunner");
+		Class<?> clazz = bundle.loadClass(ANT_RUNNER_CLASS_NAME);
 		Object antRunner = clazz.getDeclaredConstructor().newInstance();
-		assertInstanceOf(antRunner, "org.eclipse.ant.core.AntRunner", "java.lang.Runnable");
+		assertInstanceOf(antRunner, ANT_RUNNER_CLASS_NAME, "java.lang.Runnable");
 	}
 
 	private static Bundle getBundle(String bundleName) {

--- a/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
+++ b/runtime/tests/org.eclipse.core.expressions.tests/src/org/eclipse/core/internal/expressions/tests/ExpressionTestsPluginUnloading.java
@@ -87,8 +87,8 @@ public class ExpressionTestsPluginUnloading {
 		assertInstanceOf(exprObj, "java.lang.Runnable", "java.lang.String");
 		assertInstanceOf(exprObj, "java.io.Serializable", "org.eclipse.equinox.app.IApplication");
 
-		assertInstanceOf(antObj, "org.eclipse.equinox.app.IApplication", "java.lang.String");
-		assertInstanceOf(antObj, "java.lang.Object", "java.lang.Runnable");
+		assertInstanceOf(antObj, "org.eclipse.equinox.app.IApplication", "java.lang.Runnable");
+		assertInstanceOf(antObj, "java.lang.Object", "java.io.Serializable");
 	}
 
 	static String stateToString(int state) {


### PR DESCRIPTION
…n tests

The ExpressionTestsPluginUnloading test was using com.ibm.icu bundle for testing plugin loading/unloading and classloader isolation. This change replaces it with org.eclipse.ant.core bundle to support removal of com.ibm.icu from the platform.

Changes:
- Replace fake com.ibm.icu.text.DecimalFormat with org.eclipse.ant.core.AntRunner
- Update test to use org.eclipse.ant.core bundle instead of com.ibm.icu
- Adjust instanceof checks to match new bundle's class interfaces
- org.eclipse.ant.core is a suitable replacement as it can be safely stopped/restarted without affecting test execution