### PR TITLE
Build Monitor: per-builder events and example view

### DIFF
--- a/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
+++ b/resources/bundles/org.eclipse.core.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.resources; singleton:=true
-Bundle-Version: 3.24.0.qualifier
+Bundle-Version: 3.25.0.qualifier
 Bundle-Activator: org.eclipse.core.resources.ResourcesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/BuildManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/BuildManager.java
@@ -49,6 +49,7 @@ import org.eclipse.core.resources.IIncrementalProjectBuilder2;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
@@ -262,6 +263,11 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 			currentTree = ((trigger == IncrementalProjectBuilder.FULL_BUILD) || clean) ? null : workspace.getElementTree();
 			int depth = -1;
 			ISchedulingRule rule = null;
+			IProject builderProject = builder.getProject();
+			ICommand builderCommand = builder.getCommand();
+			String builderName = builderCommand != null ? builderCommand.getBuilderName() : null;
+			workspace.broadcastProjectBuildEvent(builderProject, builderName,
+					IResourceChangeEvent.PRE_PROJECT_BUILD, trigger);
 			try {
 				//short-circuit if none of the projects this builder cares about have changed.
 				if (!needsBuild(currentBuilder, trigger)) {
@@ -274,9 +280,9 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 				String name = currentBuilder.getLabel();
 				String message;
 				if (name != null) {
-					message = NLS.bind(Messages.events_invoking_2, name, builder.getProject().getFullPath());
+					message = NLS.bind(Messages.events_invoking_2, name, builderProject.getFullPath());
 				} else {
-					message = NLS.bind(Messages.events_invoking_1, builder.getProject().getFullPath());
+					message = NLS.bind(Messages.events_invoking_1, builderProject.getFullPath());
 				}
 				monitor.subTask(message);
 				hookStartBuild(builder, trigger);
@@ -302,7 +308,9 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 				//do the build
 				SafeRunner.run(getSafeRunnable(currentBuilder, trigger, args, status, monitor));
 			} finally {
-				// Re-acquire the WS lock, then release the scheduling rule
+				// Re-acquire the WS lock, then release the scheduling rule, so
+				// POST_PROJECT_BUILD listeners see the same locking state as
+				// PRE_PROJECT_BUILD listeners did: WS lock held, no rule held.
 				if (depth >= 0) {
 					getWorkManager().endUnprotected(depth);
 				}
@@ -313,23 +321,28 @@ public class BuildManager implements ICoreConstants, IManager, ILifecycleListene
 						throw handleRuleConflict(false, currentBuilder, e);
 					}
 				}
-				// Be sure to clean up after ourselves.
-				if (clean || currentBuilder.wasForgetStateRequested()) {
-					currentBuilder.setLastBuiltTree(null);
-				} else if (currentBuilder.wasRememberStateRequested()) {
-					// If remember last build state, and FULL_BUILD
-					// last tree must be set to => null for next build
-					if (trigger == IncrementalProjectBuilder.FULL_BUILD) {
+				try {
+					workspace.broadcastProjectBuildEvent(builderProject, builderName,
+							IResourceChangeEvent.POST_PROJECT_BUILD, trigger);
+				} finally {
+					// Be sure to clean up after ourselves.
+					if (clean || currentBuilder.wasForgetStateRequested()) {
 						currentBuilder.setLastBuiltTree(null);
+					} else if (currentBuilder.wasRememberStateRequested()) {
+						// If remember last build state, and FULL_BUILD
+						// last tree must be set to => null for next build
+						if (trigger == IncrementalProjectBuilder.FULL_BUILD) {
+							currentBuilder.setLastBuiltTree(null);
+						}
+						// else don't modify the last built tree
+					} else {
+						// remember the current state as the last built state.
+						ElementTree lastTree = workspace.getElementTree();
+						lastTree.immutable();
+						currentBuilder.setLastBuiltTree(lastTree);
 					}
-					// else don't modify the last built tree
-				} else {
-					// remember the current state as the last built state.
-					ElementTree lastTree = workspace.getElementTree();
-					lastTree.immutable();
-					currentBuilder.setLastBuiltTree(lastTree);
+					hookEndBuild(builder);
 				}
-				hookEndBuild(builder);
 			}
 		} finally {
 			currentBuilders.remove(currentBuilder);

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/NotificationManager.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/NotificationManager.java
@@ -215,6 +215,24 @@ public class NotificationManager implements IManager, ILifecycleListener {
 	}
 
 	/**
+	 * Dispatches a per-builder build event (PRE_PROJECT_BUILD / POST_PROJECT_BUILD).
+	 * <p>
+	 * Unlike {@link #broadcastChanges}, this path does not compute a resource
+	 * delta, does not coalesce against the last build tree, and does not update
+	 * {@code lastPostBuildTree}. Per-builder events are pure timing/metadata
+	 * signals nested inside the surrounding workspace-level PRE_BUILD/POST_BUILD
+	 * pair, which continues to carry the aggregated delta.
+	 * </p>
+	 */
+	public void broadcastProjectBuildEvent(IProject project, String builderName, int type, int buildKind) {
+		if (!listeners.hasListenerFor(type)) {
+			return;
+		}
+		ResourceChangeEvent event = new ResourceChangeEvent(project, type, buildKind, project, builderName);
+		notify(getListeners(), event, false);
+	}
+
+	/**
 	 * Helper method for the save participant lifecycle computation. */
 	public void broadcastChanges(IResourceChangeListener listener, int type, IResourceDelta delta) {
 		ResourceChangeListenerList.ListenerEntry[] entries;

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/ResourceChangeEvent.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/ResourceChangeEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     James Blackburn (Broadcom Corp.) - ongoing development
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 473427
+ *     Vogella GmbH - per-builder build events
  *******************************************************************************/
 package org.eclipse.core.internal.events;
 
@@ -32,6 +33,11 @@ public class ResourceChangeEvent extends EventObject implements IResourceChangeE
 	private int trigger = 0;
 	int type;
 
+	/**
+	 * The builder id for PRE_PROJECT_BUILD / POST_PROJECT_BUILD events, or null.
+	 */
+	private String builderName;
+
 	protected ResourceChangeEvent(Object source, int type, IResource resource) {
 		super(source);
 		this.resource = resource;
@@ -43,6 +49,12 @@ public class ResourceChangeEvent extends EventObject implements IResourceChangeE
 		this.delta = delta;
 		this.trigger = buildKind;
 		this.type = type;
+	}
+
+	public ResourceChangeEvent(Object source, int type, int buildKind, IResource resource, String builderName) {
+		this(source, type, resource);
+		this.trigger = buildKind;
+		this.builderName = builderName;
 	}
 
 	/**
@@ -110,6 +122,14 @@ public class ResourceChangeEvent extends EventObject implements IResourceChangeE
 		return type;
 	}
 
+	/**
+	 * @see IResourceChangeEvent#getBuilderName()
+	 */
+	@Override
+	public String getBuilderName() {
+		return builderName;
+	}
+
 	public void setDelta(IResourceDelta value) {
 		delta = value;
 	}
@@ -136,6 +156,12 @@ public class ResourceChangeEvent extends EventObject implements IResourceChangeE
 			case PRE_REFRESH :
 				output.append("PRE_REFRESH"); //$NON-NLS-1$
 				break;
+			case PRE_PROJECT_BUILD :
+				output.append("PRE_PROJECT_BUILD"); //$NON-NLS-1$
+				break;
+			case POST_PROJECT_BUILD :
+				output.append("POST_PROJECT_BUILD"); //$NON-NLS-1$
+				break;
 			default :
 				output.append("?"); //$NON-NLS-1$
 				break;
@@ -157,6 +183,9 @@ public class ResourceChangeEvent extends EventObject implements IResourceChangeE
 				break;
 		}
 		output.append("\nResource: " + (resource == null ? "null" : resource)); //$NON-NLS-1$ //$NON-NLS-2$
+		if (builderName != null) {
+			output.append("\nBuilder: " + builderName); //$NON-NLS-1$
+		}
 		output.append("\nDelta:" + (delta == null ? " null" : ((ResourceDelta) delta).toDeepDebugString())); //$NON-NLS-1$ //$NON-NLS-2$
 		return output.toString();
 	}

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/ResourceChangeListenerList.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/events/ResourceChangeListenerList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ package org.eclipse.core.internal.events;
 
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.eclipse.core.resources.IResourceChangeListener;
 
 /**
@@ -44,22 +45,18 @@ public class ResourceChangeListenerList {
 
 		@Override
 		public String toString() {
-			StringBuilder sb = new StringBuilder();
-			sb.append("Listener [eventMask="); //$NON-NLS-1$
-			sb.append(eventMask);
-			sb.append(", "); //$NON-NLS-1$
-			sb.append(listener);
-			sb.append("]"); //$NON-NLS-1$
-			return sb.toString();
+			return "Listener [eventMask=" + eventMask + ", " + listener + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		}
 	}
 
-	private volatile int count1 = 0;
-	private volatile int count2 = 0;
-	private volatile int count4 = 0;
-	private volatile int count8 = 0;
-	private volatile int count16 = 0;
-	private volatile int count32 = 0;
+	/**
+	 * Per-event-bit listener counts, indexed by
+	 * {@code Integer.numberOfTrailingZeros(eventMask)}. An
+	 * {@link AtomicIntegerArray} preserves the per-element volatile read
+	 * semantics that {@link #hasListenerFor(int)} relies on outside the
+	 * synchronized {@link #add}/{@link #remove}/{@link #clear} paths.
+	 */
+	private final AtomicIntegerArray bitCounts = new AtomicIntegerArray(Integer.SIZE);
 
 	/**
 	 * The list of listeners.
@@ -79,41 +76,20 @@ public class ResourceChangeListenerList {
 			remove(listener);
 			return;
 		}
-		ResourceChangeListenerList.ListenerEntry entry = new ResourceChangeListenerList.ListenerEntry(listener, mask);
+		ListenerEntry entry = new ListenerEntry(listener, mask);
 		final int oldSize = listeners.size();
 		// check for duplicates using identity
 		for (int i = 0; i < oldSize; ++i) {
 			ListenerEntry oldEntry = listeners.get(i);
 			if (oldEntry.listener == listener) {
-				removing(oldEntry.eventMask);
-				adding(mask);
+				adjust(oldEntry.eventMask, -1);
+				adjust(mask, +1);
 				listeners.set(i, entry);
 				return;
 			}
 		}
-		adding(mask);
+		adjust(mask, +1);
 		listeners.add(entry);
-	}
-
-	private void adding(int mask) {
-		if ((mask & 1) != 0) {
-			count1++;
-		}
-		if ((mask & 2) != 0) {
-			count2++;
-		}
-		if ((mask & 4) != 0) {
-			count4++;
-		}
-		if ((mask & 8) != 0) {
-			count8++;
-		}
-		if ((mask & 16) != 0) {
-			count16++;
-		}
-		if ((mask & 32) != 0) {
-			count32++;
-		}
 	}
 
 	/**
@@ -125,22 +101,11 @@ public class ResourceChangeListenerList {
 	}
 
 	public boolean hasListenerFor(int event) {
-		switch (event) {
-		case 1:
-			return count1 > 0;
-		case 2:
-			return count2 > 0;
-		case 4:
-			return count4 > 0;
-		case 8:
-			return count8 > 0;
-		case 16:
-			return count16 > 0;
-		case 32:
-			return count32 > 0;
-		default:
+		// event is expected to be a single bit (a power of two)
+		if (event <= 0 || Integer.bitCount(event) != 1) {
 			return false;
 		}
+		return bitCounts.get(Integer.numberOfTrailingZeros(event)) > 0;
 	}
 
 	/**
@@ -155,7 +120,7 @@ public class ResourceChangeListenerList {
 		for (int i = 0; i < oldSize; ++i) {
 			ListenerEntry oldEntry = listeners.get(i);
 			if (oldEntry.listener == listener) {
-				removing(oldEntry.eventMask);
+				adjust(oldEntry.eventMask, -1);
 				listeners.remove(i);
 				return;
 			}
@@ -164,44 +129,22 @@ public class ResourceChangeListenerList {
 
 	public synchronized void clear() {
 		listeners.clear();
-		count1 = 0;
-		count2 = 0;
-		count4 = 0;
-		count8 = 0;
-		count16 = 0;
-		count32 = 0;
+		for (int i = 0; i < bitCounts.length(); i++) {
+			bitCounts.set(i, 0);
+		}
 	}
 
-	private void removing(int mask) {
-		if ((mask & 1) != 0) {
-			count1--;
-		}
-		if ((mask & 2) != 0) {
-			count2--;
-		}
-		if ((mask & 4) != 0) {
-			count4--;
-		}
-		if ((mask & 8) != 0) {
-			count8--;
-		}
-		if ((mask & 16) != 0) {
-			count16--;
-		}
-		if ((mask & 32) != 0) {
-			count32--;
+	private void adjust(int mask, int delta) {
+		int remaining = mask;
+		while (remaining != 0) {
+			int bit = Integer.numberOfTrailingZeros(remaining);
+			bitCounts.addAndGet(bit, delta);
+			remaining &= remaining - 1;
 		}
 	}
 
 	@Override
 	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("ResourceChangeListenerList ["); //$NON-NLS-1$
-		if (listeners != null) {
-			builder.append("listeners="); //$NON-NLS-1$
-			builder.append(listeners.toString());
-		}
-		builder.append("]"); //$NON-NLS-1$
-		return builder.toString();
+		return "ResourceChangeListenerList [listeners=" + listeners + "]"; //$NON-NLS-1$ //$NON-NLS-2$
 	}
 }

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java
@@ -459,6 +459,15 @@ public class Workspace extends PlatformObject implements IWorkspace, ICoreConsta
 	}
 
 	/**
+	 * Broadcasts a per-builder build event. The {@code type} must be either
+	 * {@link IResourceChangeEvent#PRE_PROJECT_BUILD} or
+	 * {@link IResourceChangeEvent#POST_PROJECT_BUILD}.
+	 */
+	public void broadcastProjectBuildEvent(IProject project, String builderName, int type, int buildTrigger) {
+		notificationManager.broadcastProjectBuildEvent(project, builderName, type, buildTrigger);
+	}
+
+	/**
 	 * Broadcasts an internal workspace lifecycle event to interested
 	 * internal listeners.
 	 */

--- a/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IResourceChangeEvent.java
+++ b/resources/bundles/org.eclipse.core.resources/src/org/eclipse/core/resources/IResourceChangeEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Vogella GmbH - per-builder build events
  *******************************************************************************/
 package org.eclipse.core.resources;
 
@@ -85,6 +86,26 @@ import org.eclipse.core.runtime.IProgressMonitor;
  *    If the event is fired by a project refresh the <code>getResource</code>
  *    method returns the project being refreshed.
  *    The workspace is closed for changes during notification of these events.
+ *   </li>
+ *   <li>
+ *    Before-the-fact reports of a single builder about to run on a single
+ *    project. Event type is <code>PRE_PROJECT_BUILD</code>, <code>getSource</code>
+ *    returns the {@link IProject} being built, <code>getBuilderName</code>
+ *    returns the id of the builder that is about to run, and <code>getBuildKind</code>
+ *    returns the kind of build. Fired once per builder per project, nested
+ *    inside a surrounding <code>PRE_BUILD</code>/<code>POST_BUILD</code> pair.
+ *    No resource delta is provided.
+ *   </li>
+ *   <li>
+ *    After-the-fact reports of a single builder having run on a single project.
+ *    Event type is <code>POST_PROJECT_BUILD</code>, <code>getSource</code>
+ *    returns the {@link IProject} that was built, <code>getBuilderName</code>
+ *    returns the id of the builder that ran, and <code>getBuildKind</code>
+ *    returns the kind of build. Fired once per builder per project, nested
+ *    inside a surrounding <code>PRE_BUILD</code>/<code>POST_BUILD</code> pair.
+ *    No resource delta is provided.
+ *    When the workspace is configured for parallel builds, events for
+ *    different projects may be delivered concurrently on different threads.
  *   </li>
  * </ul>
  * <p>
@@ -180,6 +201,42 @@ public interface IResourceChangeEvent {
 	int PRE_REFRESH = 32;
 
 	/**
+	 * Event type constant (bit mask) indicating a before-the-fact report
+	 * that a single builder is about to run on a single project.
+	 * <p>
+	 * <code>getSource</code> returns the {@link IProject} being built,
+	 * <code>getBuilderName</code> returns the id of the builder, and
+	 * <code>getBuildKind</code> returns the kind of build. No resource
+	 * delta is provided. See class comments for further details.
+	 * </p>
+	 *
+	 * @see #getType()
+	 * @see #getSource()
+	 * @see #getBuilderName()
+	 * @see #getBuildKind()
+	 * @since 3.25
+	 */
+	int PRE_PROJECT_BUILD = 64;
+
+	/**
+	 * Event type constant (bit mask) indicating an after-the-fact report
+	 * that a single builder has run on a single project.
+	 * <p>
+	 * <code>getSource</code> returns the {@link IProject} that was built,
+	 * <code>getBuilderName</code> returns the id of the builder, and
+	 * <code>getBuildKind</code> returns the kind of build. No resource
+	 * delta is provided. See class comments for further details.
+	 * </p>
+	 *
+	 * @see #getType()
+	 * @see #getSource()
+	 * @see #getBuilderName()
+	 * @see #getBuildKind()
+	 * @since 3.25
+	 */
+	int POST_PROJECT_BUILD = 128;
+
+	/**
 	 * Returns all marker deltas of the specified type that are associated
 	 * with resource deltas for this event. If <code>includeSubtypes</code>
 	 * is <code>false</code>, only marker deltas whose type exactly matches
@@ -262,6 +319,25 @@ public interface IResourceChangeEvent {
 	 * @see #PRE_CLOSE
 	 * @see #PRE_DELETE
 	 * @see #PRE_REFRESH
+	 * @see #PRE_PROJECT_BUILD
+	 * @see #POST_PROJECT_BUILD
 	 */
 	int getType();
+
+	/**
+	 * Returns the id of the builder this event relates to, or <code>null</code>
+	 * if not applicable to this type of event.
+	 * <p>
+	 * For {@link #PRE_PROJECT_BUILD} and {@link #POST_PROJECT_BUILD} events
+	 * this returns the builder id as declared in the project's build spec
+	 * (the <code>ICommand</code>'s builder name). For all other event types
+	 * this returns <code>null</code>.
+	 * </p>
+	 *
+	 * @return the builder id, or <code>null</code> if not applicable
+	 * @since 3.25
+	 */
+	default String getBuilderName() {
+		return null;
+	}
 }

--- a/resources/examples/org.eclipse.ui.examples.buildmonitor/META-INF/MANIFEST.MF
+++ b/resources/examples/org.eclipse.ui.examples.buildmonitor/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Automatic-Module-Name: org.eclipse.ui.examples.buildmonitor
+Bundle-Name: Build Monitor Example
+Bundle-SymbolicName: org.eclipse.ui.examples.buildmonitor;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse.org
+Require-Bundle: org.eclipse.core.resources;bundle-version="[3.25.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.34.0,4.0.0)",
+ org.eclipse.ui;bundle-version="3.208.0",
+ org.eclipse.ui.ide,
+ org.eclipse.jface
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/resources/examples/org.eclipse.ui.examples.buildmonitor/about.html
+++ b/resources/examples/org.eclipse.ui.examples.buildmonitor/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>About</title>
+</head>
+<body lang="EN-US">
+	<h2>About This Content</h2>
+
+	<p>April 20, 2026</p>
+	<h3>License</h3>
+
+	<p>
+		The Eclipse Foundation makes available all content in this plug-in
+		(&quot;Content&quot;). Unless otherwise indicated below, the Content
+		is provided to you under the terms and conditions of the Eclipse
+		Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+		available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+		For purposes of the EPL, &quot;Program&quot; will mean the Content.
+	</p>
+
+	<p>
+		If you did not receive this Content directly from the Eclipse
+		Foundation, the Content is being redistributed by another party
+		(&quot;Redistributor&quot;) and different terms and conditions may
+		apply to your use of any object code in the Content. Check the
+		Redistributor's license that was provided with the Content. If no such
+		license exists, contact the Redistributor. Unless otherwise indicated
+		below, the terms and conditions of the EPL still apply to any source
+		code in the Content and such source code may be obtained at <a
+			href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+	</p>
+
+</body>
+</html>

--- a/resources/examples/org.eclipse.ui.examples.buildmonitor/build.properties
+++ b/resources/examples/org.eclipse.ui.examples.buildmonitor/build.properties
@@ -1,0 +1,7 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml,\
+               about.html
+src.includes = about.html

--- a/resources/examples/org.eclipse.ui.examples.buildmonitor/plugin.xml
+++ b/resources/examples/org.eclipse.ui.examples.buildmonitor/plugin.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>
+   <extension
+         point="org.eclipse.ui.views">
+      <category
+            id="org.eclipse.ui.examples.buildmonitor.category"
+            name="Build Monitor Example"/>
+      <view
+            allowMultiple="false"
+            category="org.eclipse.ui.examples.buildmonitor.category"
+            class="org.eclipse.ui.examples.buildmonitor.BuildMonitorView"
+            id="org.eclipse.ui.examples.buildmonitor.view"
+            name="Build Monitor"
+            restorable="true"/>
+   </extension>
+</plugin>

--- a/resources/examples/org.eclipse.ui.examples.buildmonitor/src/org/eclipse/ui/examples/buildmonitor/BuildMonitorView.java
+++ b/resources/examples/org.eclipse.ui.examples.buildmonitor/src/org/eclipse/ui/examples/buildmonitor/BuildMonitorView.java
@@ -1,0 +1,238 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.examples.buildmonitor;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IToolBarManager;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.TreeViewerColumn;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.ui.examples.buildmonitor.BuildRecorder.BuilderEntry;
+import org.eclipse.ui.examples.buildmonitor.BuildRecorder.ProjectEntry;
+import org.eclipse.ui.examples.buildmonitor.BuildRecorder.Session;
+import org.eclipse.ui.part.ViewPart;
+
+/**
+ * View that shows recent build sessions with per-project and per-builder timing.
+ * Sessions are top-level rows; expand to see per-project aggregates, expand again
+ * to see individual builder runs.
+ */
+public class BuildMonitorView extends ViewPart {
+
+	private static final DateTimeFormatter TIME = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
+
+	private BuildRecorder recorder;
+	private BuildRecorder.Listener recorderListener;
+	private TreeViewer viewer;
+
+	@Override
+	public void createPartControl(Composite parent) {
+		recorder = new BuildRecorder();
+		recorder.start();
+
+		viewer = new TreeViewer(parent, SWT.FULL_SELECTION | SWT.H_SCROLL | SWT.V_SCROLL);
+		Tree tree = viewer.getTree();
+		tree.setHeaderVisible(true);
+		tree.setLinesVisible(true);
+
+		addColumn("Build / Project / Builder", 320, new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				if (element instanceof Session s) {
+					return "Build " + TIME.format(s.getStartedAt()) + " — " + kindLabel(s.getBuildKind());
+				}
+				if (element instanceof ProjectEntry p) {
+					return p.getProject().getName();
+				}
+				if (element instanceof BuilderEntry b) {
+					return b.getBuilderName() == null ? "<unknown>" : b.getBuilderName();
+				}
+				return String.valueOf(element);
+			}
+		});
+		addColumn("Pure build time", 120, new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				if (element instanceof Session s) {
+					long sum = 0;
+					for (ProjectEntry p : s.getProjects()) {
+						sum += p.getPureBuildTimeNanos();
+					}
+					return formatMillis(sum);
+				}
+				if (element instanceof ProjectEntry p) {
+					return formatMillis(p.getPureBuildTimeNanos());
+				}
+				if (element instanceof BuilderEntry b) {
+					return formatMillis(b.getDurationNanos());
+				}
+				return "";
+			}
+		});
+		addColumn("Time until ready", 140, new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				if (element instanceof Session s) {
+					return formatMillis(s.getDurationNanos());
+				}
+				if (element instanceof ProjectEntry p) {
+					return formatMillis(p.getTimeUntilReadyNanos());
+				}
+				return "";
+			}
+		});
+
+		viewer.setContentProvider(new BuildMonitorContentProvider());
+		viewer.setInput(recorder);
+
+		recorderListener = this::refreshAsync;
+		recorder.addListener(recorderListener);
+
+		IToolBarManager toolBar = getViewSite().getActionBars().getToolBarManager();
+		toolBar.add(new Action("Clear") {
+			@Override
+			public void run() {
+				recorder.clear();
+			}
+		});
+	}
+
+	@Override
+	public void setFocus() {
+		viewer.getControl().setFocus();
+	}
+
+	@Override
+	public void dispose() {
+		if (recorder != null) {
+			if (recorderListener != null) {
+				recorder.removeListener(recorderListener);
+			}
+			recorder.stop();
+		}
+		super.dispose();
+	}
+
+	private void addColumn(String title, int width, ColumnLabelProvider provider) {
+		TreeViewerColumn col = new TreeViewerColumn(viewer, SWT.NONE);
+		col.getColumn().setText(title);
+		col.getColumn().setWidth(width);
+		col.setLabelProvider(provider);
+	}
+
+	private void refreshAsync() {
+		if (viewer == null || viewer.getControl().isDisposed()) {
+			return;
+		}
+		Display display = viewer.getControl().getDisplay();
+		if (display.isDisposed()) {
+			return;
+		}
+		display.asyncExec(() -> {
+			if (viewer != null && !viewer.getControl().isDisposed()) {
+				viewer.refresh();
+			}
+		});
+	}
+
+	private static String formatMillis(long nanos) {
+		if (nanos <= 0) {
+			return "—";
+		}
+		double ms = nanos / 1_000_000.0;
+		if (ms < 1) {
+			return String.format(Locale.ROOT, "%.2f ms", ms);
+		}
+		if (ms < 1000) {
+			return String.format(Locale.ROOT, "%.0f ms", ms);
+		}
+		return String.format(Locale.ROOT, "%.2f s", ms / 1000.0);
+	}
+
+	private static boolean builderDidWork(BuilderEntry b) {
+		return b.getDurationNanos() >= SKIPPED_BUILDER_THRESHOLD_NANOS;
+	}
+
+	private static boolean projectDidWork(ProjectEntry p) {
+		return p.getBuilders().stream().anyMatch(BuildMonitorView::builderDidWork);
+	}
+
+	private static String kindLabel(int kind) {
+		return switch (kind) {
+			case IncrementalProjectBuilder.FULL_BUILD -> "FULL";
+			case IncrementalProjectBuilder.INCREMENTAL_BUILD -> "INCREMENTAL";
+			case IncrementalProjectBuilder.AUTO_BUILD -> "AUTO";
+			case IncrementalProjectBuilder.CLEAN_BUILD -> "CLEAN";
+			default -> "KIND=" + kind;
+		};
+	}
+
+	/** Hide builders that short-circuited via needsBuild (< 100 µs overhead). */
+	private static final long SKIPPED_BUILDER_THRESHOLD_NANOS = 100_000L;
+
+	private static final class BuildMonitorContentProvider implements ITreeContentProvider {
+		@Override
+		public Object[] getElements(Object input) {
+			if (input instanceof BuildRecorder r) {
+				List<Session> sessions = r.getSessions();
+				// newest first
+				Object[] arr = sessions.toArray();
+				Collections.reverse(Arrays.asList(arr));
+				return arr;
+			}
+			return new Object[0];
+		}
+
+		@Override
+		public Object[] getChildren(Object parent) {
+			if (parent instanceof Session s) {
+				return s.getProjects().stream()
+						.filter(BuildMonitorView::projectDidWork)
+						.toArray();
+			}
+			if (parent instanceof ProjectEntry p) {
+				return p.getBuilders().stream()
+						.filter(BuildMonitorView::builderDidWork)
+						.toArray();
+			}
+			return new Object[0];
+		}
+
+		@Override
+		public Object getParent(Object element) {
+			return null;
+		}
+
+		@Override
+		public boolean hasChildren(Object element) {
+			if (element instanceof Session s) {
+				return s.getProjects().stream().anyMatch(BuildMonitorView::projectDidWork);
+			}
+			if (element instanceof ProjectEntry p) {
+				return p.getBuilders().stream().anyMatch(BuildMonitorView::builderDidWork);
+			}
+			return false;
+		}
+	}
+}

--- a/resources/examples/org.eclipse.ui.examples.buildmonitor/src/org/eclipse/ui/examples/buildmonitor/BuildRecorder.java
+++ b/resources/examples/org.eclipse.ui.examples.buildmonitor/src/org/eclipse/ui/examples/buildmonitor/BuildRecorder.java
@@ -1,0 +1,299 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.ui.examples.buildmonitor;
+
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.ILog;
+
+/**
+ * Listens to workspace build events and per-builder build events, and records
+ * a session tree that the view can display.
+ * <p>
+ * One {@link Session} is created for each workspace-level PRE_BUILD / POST_BUILD
+ * pair. Inside a session, per-builder events are attributed to their
+ * {@link ProjectEntry} and {@link BuilderEntry}. To match PRE / POST events
+ * correctly under parallel builds, each thread uses its own stack of
+ * in-progress builder entries; a given builder runs synchronously on one
+ * thread, so push-on-PRE / pop-on-POST is race-free.
+ */
+public final class BuildRecorder {
+
+	public interface Listener {
+		void sessionsChanged();
+	}
+
+	private static final int MAX_SESSIONS = 50;
+
+	private final int mask = IResourceChangeEvent.PRE_BUILD | IResourceChangeEvent.POST_BUILD
+			| IResourceChangeEvent.PRE_PROJECT_BUILD | IResourceChangeEvent.POST_PROJECT_BUILD;
+
+	private final IResourceChangeListener eventListener = this::onResourceChangeEvent;
+
+	private final List<Session> sessions = Collections.synchronizedList(new ArrayList<>());
+	private final List<Listener> listeners = new CopyOnWriteArrayList<>();
+
+	private final ThreadLocal<Deque<BuilderEntry>> threadStack = ThreadLocal.withInitial(ArrayDeque::new);
+
+	private volatile Session currentSession;
+
+	public void start() {
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(eventListener, mask);
+	}
+
+	public void stop() {
+		ResourcesPlugin.getWorkspace().removeResourceChangeListener(eventListener);
+	}
+
+	public void addListener(Listener listener) {
+		listeners.add(listener);
+	}
+
+	public void removeListener(Listener listener) {
+		listeners.remove(listener);
+	}
+
+	public List<Session> getSessions() {
+		synchronized (sessions) {
+			return new ArrayList<>(sessions);
+		}
+	}
+
+	public void clear() {
+		synchronized (sessions) {
+			sessions.clear();
+		}
+		fireChanged();
+	}
+
+	private void onResourceChangeEvent(IResourceChangeEvent event) {
+		switch (event.getType()) {
+			case IResourceChangeEvent.PRE_BUILD -> onWorkspacePreBuild(event);
+			case IResourceChangeEvent.POST_BUILD -> onWorkspacePostBuild(event);
+			case IResourceChangeEvent.PRE_PROJECT_BUILD -> onProjectPreBuild(event);
+			case IResourceChangeEvent.POST_PROJECT_BUILD -> onProjectPostBuild(event);
+			default -> { /* ignore */ }
+		}
+	}
+
+	private void onWorkspacePreBuild(IResourceChangeEvent event) {
+		Session session = new Session(System.nanoTime(), Instant.now(), event.getBuildKind());
+		currentSession = session;
+	}
+
+	private void onWorkspacePostBuild(IResourceChangeEvent event) {
+		Session session = currentSession;
+		if (session == null) {
+			return;
+		}
+		session.finish(System.nanoTime());
+		currentSession = null;
+		synchronized (sessions) {
+			sessions.add(session);
+			while (sessions.size() > MAX_SESSIONS) {
+				sessions.remove(0);
+			}
+		}
+		fireChanged();
+	}
+
+	private void onProjectPreBuild(IResourceChangeEvent event) {
+		Session session = currentSession;
+		if (session == null || !(event.getSource() instanceof IProject project)) {
+			return;
+		}
+		BuilderEntry entry = new BuilderEntry(event.getBuilderName(), event.getBuildKind(), System.nanoTime());
+		session.addBuilderStart(project, entry);
+		threadStack.get().push(entry);
+	}
+
+	private void onProjectPostBuild(IResourceChangeEvent event) {
+		Deque<BuilderEntry> stack = threadStack.get();
+		BuilderEntry entry = stack.pollFirst();
+		if (entry == null) {
+			return;
+		}
+		entry.finish(System.nanoTime());
+		Session session = currentSession;
+		if (session != null && event.getSource() instanceof IProject project) {
+			session.noteBuilderEnd(project, entry);
+		}
+	}
+
+	private void fireChanged() {
+		for (Listener l : listeners) {
+			try {
+				l.sessionsChanged();
+			} catch (RuntimeException e) {
+				// a broken listener must not poison the notification, but log it
+				ILog.get().error("Build Monitor listener threw while handling sessionsChanged", e); //$NON-NLS-1$
+			}
+		}
+	}
+
+	public static final class Session {
+		private final long startNanos;
+		private final Instant startedAt;
+		private final int buildKind;
+		private final Map<IProject, ProjectEntry> projects = Collections.synchronizedMap(new LinkedHashMap<>());
+		private volatile long endNanos = -1;
+
+		Session(long startNanos, Instant startedAt, int buildKind) {
+			this.startNanos = startNanos;
+			this.startedAt = startedAt;
+			this.buildKind = buildKind;
+		}
+
+		void addBuilderStart(IProject project, BuilderEntry entry) {
+			projects.computeIfAbsent(project, ProjectEntry::new).add(entry, startNanos);
+		}
+
+		void noteBuilderEnd(IProject project, BuilderEntry entry) {
+			ProjectEntry p = projects.get(project);
+			if (p != null) {
+				p.noteEnd(entry);
+			}
+		}
+
+		void finish(long endNanos) {
+			this.endNanos = endNanos;
+		}
+
+		public Instant getStartedAt() {
+			return startedAt;
+		}
+
+		public int getBuildKind() {
+			return buildKind;
+		}
+
+		public long getDurationNanos() {
+			return endNanos < 0 ? System.nanoTime() - startNanos : endNanos - startNanos;
+		}
+
+		public long getStartNanos() {
+			return startNanos;
+		}
+
+		public List<ProjectEntry> getProjects() {
+			synchronized (projects) {
+				return new ArrayList<>(projects.values());
+			}
+		}
+	}
+
+	public static final class ProjectEntry {
+		private final IProject project;
+		private final List<BuilderEntry> builders = Collections.synchronizedList(new ArrayList<>());
+		private volatile long lastEndNanos = Long.MIN_VALUE;
+		private volatile long sessionStartNanos = -1;
+
+		ProjectEntry(IProject project) {
+			this.project = project;
+		}
+
+		synchronized void add(BuilderEntry entry, long sessionStart) {
+			if (sessionStartNanos < 0) {
+				sessionStartNanos = sessionStart;
+			}
+			builders.add(entry);
+		}
+
+		synchronized void noteEnd(BuilderEntry entry) {
+			if (entry.getEndNanos() > lastEndNanos) {
+				lastEndNanos = entry.getEndNanos();
+			}
+		}
+
+		public IProject getProject() {
+			return project;
+		}
+
+		public List<BuilderEntry> getBuilders() {
+			synchronized (builders) {
+				return new ArrayList<>(builders);
+			}
+		}
+
+		/**
+		 * Pure build time: sum of each builder's (end - start).
+		 */
+		public long getPureBuildTimeNanos() {
+			long sum = 0;
+			synchronized (builders) {
+				for (BuilderEntry b : builders) {
+					sum += b.getDurationNanos();
+				}
+			}
+			return sum;
+		}
+
+		/**
+		 * Time until ready: from the start of the enclosing workspace build to
+		 * the moment this project's last builder finished.
+		 */
+		public long getTimeUntilReadyNanos() {
+			if (lastEndNanos == Long.MIN_VALUE) {
+				return 0;
+			}
+			return lastEndNanos - sessionStartNanos;
+		}
+	}
+
+	public static final class BuilderEntry {
+		private final String builderName;
+		private final int buildKind;
+		private final long startNanos;
+		private volatile long endNanos = -1;
+
+		BuilderEntry(String builderName, int buildKind, long startNanos) {
+			this.builderName = builderName;
+			this.buildKind = buildKind;
+			this.startNanos = startNanos;
+		}
+
+		void finish(long endNanos) {
+			this.endNanos = endNanos;
+		}
+
+		public String getBuilderName() {
+			return builderName;
+		}
+
+		public int getBuildKind() {
+			return buildKind;
+		}
+
+		public long getStartNanos() {
+			return startNanos;
+		}
+
+		public long getEndNanos() {
+			return endNanos;
+		}
+
+		public long getDurationNanos() {
+			return endNanos < 0 ? 0 : endNanos - startNanos;
+		}
+	}
+}

--- a/resources/examples/pom.xml
+++ b/resources/examples/pom.xml
@@ -25,5 +25,6 @@
   
   <modules>
     <module>org.eclipse.ui.examples.filesystem</module>
+    <module>org.eclipse.ui.examples.buildmonitor</module>
   </modules>
 </project>

--- a/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ProjectBuildEventTest.java
+++ b/resources/tests/org.eclipse.core.tests.resources/src/org/eclipse/core/tests/internal/builders/ProjectBuildEventTest.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.core.tests.internal.builders;
+
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.createTestMonitor;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.setAutoBuilding;
+import static org.eclipse.core.tests.resources.ResourceTestUtil.updateProjectDescription;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.tests.resources.util.WorkspaceResetExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests the PRE_PROJECT_BUILD and POST_PROJECT_BUILD events. In particular it
+ * asserts that events fire even when a builder is short-circuited by the
+ * needsBuild check (e.g. an incremental build after Project > Clean where no
+ * source changed).
+ */
+@ExtendWith(WorkspaceResetExtension.class)
+public class ProjectBuildEventTest {
+
+	private record Record(int type, Object source, String builderName, int buildKind) {
+	}
+
+	private final List<Record> events = new CopyOnWriteArrayList<>();
+	private final IResourceChangeListener listener = event -> events.add(
+			new Record(event.getType(), event.getSource(), event.getBuilderName(), event.getBuildKind()));
+
+	@BeforeEach
+	public void setUp() {
+		int mask = IResourceChangeEvent.PRE_BUILD | IResourceChangeEvent.POST_BUILD
+				| IResourceChangeEvent.PRE_PROJECT_BUILD | IResourceChangeEvent.POST_PROJECT_BUILD;
+		getWorkspace().addResourceChangeListener(listener, mask);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		getWorkspace().removeResourceChangeListener(listener);
+	}
+
+	@Test
+	public void testPerBuilderEventsFireOnFullBuild() throws CoreException {
+		IProject project = createProjectWithBuilder("FULL");
+
+		events.clear();
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
+
+		List<Record> perBuilder = filter(IResourceChangeEvent.PRE_PROJECT_BUILD,
+				IResourceChangeEvent.POST_PROJECT_BUILD);
+		assertEquals(2, perBuilder.size(), "expected one PRE/POST_PROJECT_BUILD pair, got events: " + events);
+
+		Record pre = perBuilder.get(0);
+		Record post = perBuilder.get(1);
+		assertEquals(IResourceChangeEvent.PRE_PROJECT_BUILD, pre.type());
+		assertEquals(IResourceChangeEvent.POST_PROJECT_BUILD, post.type());
+		assertEquals(project, pre.source());
+		assertEquals(project, post.source());
+		assertEquals(DeltaVerifierBuilder.BUILDER_NAME, pre.builderName());
+		assertEquals(DeltaVerifierBuilder.BUILDER_NAME, post.builderName());
+		assertEquals(IncrementalProjectBuilder.FULL_BUILD, pre.buildKind());
+		assertEquals(IncrementalProjectBuilder.FULL_BUILD, post.buildKind());
+	}
+
+	@Test
+	public void testPerBuilderEventsFireOnCleanBuild() throws CoreException {
+		createProjectWithBuilder("CLEAN");
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
+
+		events.clear();
+		getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, createTestMonitor());
+		List<Record> perBuilder = filter(IResourceChangeEvent.PRE_PROJECT_BUILD,
+				IResourceChangeEvent.POST_PROJECT_BUILD);
+		assertEquals(2, perBuilder.size(), "CLEAN should fire one PRE/POST_PROJECT_BUILD pair, got: " + events);
+		assertEquals(IncrementalProjectBuilder.CLEAN_BUILD, perBuilder.get(0).buildKind());
+		assertEquals(IncrementalProjectBuilder.CLEAN_BUILD, perBuilder.get(1).buildKind());
+	}
+
+	@Test
+	public void testPerBuilderEventsFireOnIncrementalBuildWithNoDelta() throws CoreException {
+		createProjectWithBuilder("INC-NO-DELTA");
+		// Prime: run a full build so the builder has a last-built tree.
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
+
+		// Second incremental build without any intervening source change. The
+		// builder should be considered but short-circuited by needsBuild. Events
+		// must still fire so the Build Monitor view can render the session.
+		events.clear();
+		getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, createTestMonitor());
+		List<Record> perBuilder = filter(IResourceChangeEvent.PRE_PROJECT_BUILD,
+				IResourceChangeEvent.POST_PROJECT_BUILD);
+		assertEquals(2, perBuilder.size(),
+				"INCREMENTAL with no delta must still fire PRE/POST_PROJECT_BUILD, got: " + events);
+	}
+
+	@Test
+	public void testPerBuilderEventsNestedInsideWorkspaceBuild() throws CoreException {
+		createProjectWithBuilder("NESTED");
+
+		events.clear();
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
+
+		List<Integer> types = new ArrayList<>();
+		for (Record r : events) {
+			types.add(r.type());
+		}
+		int preBuild = types.indexOf(IResourceChangeEvent.PRE_BUILD);
+		int postBuild = types.indexOf(IResourceChangeEvent.POST_BUILD);
+		int prePrj = types.indexOf(IResourceChangeEvent.PRE_PROJECT_BUILD);
+		int postPrj = types.indexOf(IResourceChangeEvent.POST_PROJECT_BUILD);
+		assertTrue(preBuild >= 0 && postBuild > preBuild, "workspace PRE/POST_BUILD must be present and ordered: " + events);
+		assertTrue(prePrj > preBuild && prePrj < postBuild,
+				"PRE_PROJECT_BUILD must be nested inside workspace build: " + events);
+		assertTrue(postPrj > prePrj && postPrj < postBuild,
+				"POST_PROJECT_BUILD must come after its PRE and before workspace POST_BUILD: " + events);
+	}
+
+	@Test
+	public void testBuilderNameOnlyPopulatedForProjectBuildEvents() throws CoreException {
+		createProjectWithBuilder("NAME");
+		events.clear();
+		getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, createTestMonitor());
+
+		boolean sawProjectBuildWithName = false;
+		for (Record r : events) {
+			if (r.type() == IResourceChangeEvent.PRE_PROJECT_BUILD
+					|| r.type() == IResourceChangeEvent.POST_PROJECT_BUILD) {
+				assertNotNull(r.builderName(), "per-builder event must carry builder name");
+				sawProjectBuildWithName = true;
+			} else {
+				assertNull(r.builderName(), "workspace-level event must not carry builder name, got: " + r);
+			}
+		}
+		assertTrue(sawProjectBuildWithName, "expected at least one per-builder event: " + events);
+	}
+
+	private IProject createProjectWithBuilder(String tag) throws CoreException {
+		IProject project = getWorkspace().getRoot().getProject("PROJECT-" + tag);
+		setAutoBuilding(false);
+		project.create(createTestMonitor());
+		project.open(createTestMonitor());
+		updateProjectDescription(project).addingCommand(DeltaVerifierBuilder.BUILDER_NAME)
+				.withTestBuilderId("Builder-" + tag).apply();
+		return project;
+	}
+
+	private List<Record> filter(int... types) {
+		List<Record> out = new ArrayList<>();
+		for (Record r : events) {
+			for (int t : types) {
+				if (r.type() == t) {
+					out.add(r);
+					break;
+				}
+			}
+		}
+		return out;
+	}
+}


### PR DESCRIPTION
CI verification PR. Adds `PRE_PROJECT_BUILD` / `POST_PROJECT_BUILD` events to `IResourceChangeEvent`, fired per builder from `BuildManager.basicBuild`, and a new `org.eclipse.ui.examples.buildmonitor` example view that consumes them.

This branch is stacked on top of upstream PR #2664 (`Replace per-bit listener count fields with an AtomicIntegerArray` on `eclipse-platform/eclipse.platform`). The array-based bookkeeping makes the new 64/128 bitmasks work without any change to `ResourceChangeListenerList`.

---

### Fallback if upstream PR #2664 is rejected

If the `AtomicIntegerArray` refactor is not merged, the per-builder events commit needs the following addition to `ResourceChangeListenerList.java` so that `hasListenerFor(64)` and `hasListenerFor(128)` actually return `true` for registered listeners (otherwise both new events are silently dropped):

```diff
@@ -60,6 +61,8 @@ public class ResourceChangeListenerList {
 	private volatile int count8 = 0;
 	private volatile int count16 = 0;
 	private volatile int count32 = 0;
+	private volatile int count64 = 0;
+	private volatile int count128 = 0;

@@ -114,6 +117,12 @@ public class ResourceChangeListenerList {
 		if ((mask & 32) != 0) {
 			count32++;
 		}
+		if ((mask & 64) != 0) {
+			count64++;
+		}
+		if ((mask & 128) != 0) {
+			count128++;
+		}
 	}

@@ -138,6 +147,10 @@ public class ResourceChangeListenerList {
 			return count16 > 0;
 		case 32:
 			return count32 > 0;
+		case 64:
+			return count64 > 0;
+		case 128:
+			return count128 > 0;
 		default:
 			return false;
 		}

@@ -170,6 +183,8 @@ public class ResourceChangeListenerList {
 		count8 = 0;
 		count16 = 0;
 		count32 = 0;
+		count64 = 0;
+		count128 = 0;
 	}

@@ -191,6 +206,12 @@ public class ResourceChangeListenerList {
 		if ((mask & 32) != 0) {
 			count32--;
 		}
+		if ((mask & 64) != 0) {
+			count64--;
+		}
+		if ((mask & 128) != 0) {
+			count128--;
+		}
 	}
```

Recovery flow in that case: `git rebase --onto origin/master aa8786ac75` to drop the refactor commit, then apply the diff above to the per-builder events commit via `git commit --amend`.